### PR TITLE
Feature/review controller

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,14 @@
 class HomeController < ApplicationController
+  respond_to :html, :json
+
   def index
-    @civil_entries = CivilEntry.all.order("created_at DESC").decorate
+    @civil_entries = reviewed_entries.order("created_at DESC").decorate
+    respond_with @civil_entries
+  end
+
+  private
+
+  def reviewed_entries
+    CivilEntry.where(:reviewed => true)
   end
 end

--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -1,0 +1,14 @@
+class ReviewController < ApplicationController
+  respond_to :html, :json
+
+  def index
+    @unreviewed_civil_entries = unreviewed_entries.order("created_at DESC")
+    respond_with @unreviewed_civil_entries
+  end
+
+  private
+
+  def unreviewed_entries
+    CivilEntry.where(:reviewed => false)
+  end
+end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -15,12 +15,16 @@
         </tr>
       </thead>
       <tbody>
-        <% @civil_entries.each do |civil_entry| %>
-          <tr>
-            <td><%= civil_entry.serial %></td>
-            <td><%= civil_entry.created_at_formatted %></td> 
-            <td><%= civil_entry.address %></td>
-          </tr>
+        <% if @civil_entries.blank? %>
+          <p>There are currently no entries at this time.</p>
+        <% else %>
+          <% @civil_entries.each do |civil_entry| %>
+            <tr>
+              <td><%= civil_entry.serial %></td>
+              <td><%= civil_entry.created_at_formatted %></td> 
+              <td><%= civil_entry.address %></td>
+            </tr>
+          <% end %>
         <% end %>
       </tbody>
     </table>

--- a/app/views/review/index.html.erb
+++ b/app/views/review/index.html.erb
@@ -1,0 +1,27 @@
+<div class="content">
+  <div class="left"></div>
+  <div id="civil_entries">
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Card Number</th>
+          <th>Location</th>
+          <th>Reason</th> 
+        </tr>
+      </thead>
+      <tbody>
+        <% if @unreviewed_civil_entries.blank? %>
+          <p>There are currently no entries that need to be reviewed.</p>
+        <% else %>
+          <% @unreviewed_civil_entries.each do |civil_entry| %>
+            <tr>
+              <td><%= civil_entry.serial %></td>
+              <td><%= civil_entry.address %></td>
+              <td><%= civil_entry.reason %></td> 
+            </tr>
+          <% end %>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :review
+
   get 'civil_entries/qr/:serial' => Dragonfly.app.endpoint { |params, app|
     app.generate(:qr, "http://#{Rails.application.config.action_mailer.default_url_options[:host]}/civil_entries/register/#{params[:serial]}")
   }

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+RSpec.describe HomeController do
+  let(:unreviewed_civil_entry) {create(:unreviewed_civil_entry)}
+  let(:reviewed_civil_entry) {create(:civil_entry)}
+  let(:json_response) {JSON.parse(response.body)}
+
+  describe "#index" do
+    context "When there are no reviewed entries" do
+      before do
+        get :index, :format => :json
+      end
+      it "should return nothing" do
+        expect(json_response.length).to eq 0
+      end
+    end
+    context "When there are entries" do
+      context "and those entries are reviewed" do
+        before do
+          reviewed_civil_entry
+          get :index, :format => :json
+        end
+        it "should return that reviewed object" do
+          expect(json_response.length).to eq 1
+          expect(json_response.first["reviewed"]).to eq true
+        end
+      end
+      context "and those entries are not reviewed" do
+        before do
+          unreviewed_civil_entry
+          get :index, :format => :json
+        end
+        it "should return the object and it should be unreviewed" do
+          expect(json_response.length).to eq 0
+        end
+      end
+      context "and those entries are both unreviewed and reviewed" do
+        before do
+          reviewed_civil_entry
+          unreviewed_civil_entry
+          get :index, :format => :json
+        end
+        it "should return only the reviewed object" do
+          expect(json_response.length).to eq 1
+          expect(json_response.first["reviewed"]).to eq true
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/review_controller_spec.rb
+++ b/spec/controllers/review_controller_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+RSpec.describe ReviewController do
+  let(:unreviewed_civil_entry) {create(:unreviewed_civil_entry)}
+  let(:reviewed_civil_entry) {create(:civil_entry)}
+  let(:json_response) {JSON.parse(response.body)}
+
+  context "When there are no entries" do
+    before do
+      get :index, :format => :json
+    end
+    it "should not return any objects" do
+      expect(json_response.length).to eq 0
+    end
+  end
+  context "When there are entries" do
+    context "and those entries are reviewed" do
+      before do
+        reviewed_civil_entry
+        get :index, :format => :json
+      end
+      it "should return nothing" do
+        expect(json_response.length).to eq 0
+      end
+    end
+    context "and those entries are not reviewed" do
+      before do
+        unreviewed_civil_entry
+        get :index, :format => :json
+      end
+      it "should return the object and it should be unreviewed" do
+        expect(json_response.length).to eq 1
+        expect(json_response.first["reviewed"]).to eq false
+      end
+    end
+    context "and those entries are both unreviewed and reviewed" do
+      before do
+        reviewed_civil_entry
+        unreviewed_civil_entry
+        get :index, :format => :json
+      end
+      it "should return only the unreviewed object" do
+        expect(json_response.length).to eq 1
+        expect(json_response.first["reviewed"]).to eq false
+      end
+    end
+  end
+end

--- a/spec/factories/civil_entries.rb
+++ b/spec/factories/civil_entries.rb
@@ -5,10 +5,8 @@ FactoryGirl.define do
     sequence(:serial) {|n| n}
     reason "This is a reason"
     reviewed true
-  end
-  factory :unreviewed_civil_entry, :class => CivilEntry do
-    sequence(:serial) {|n| n}
-    reason "This is a reason"
-    reviewed false
+    factory :unreviewed_civil_entry do
+      reviewed false
+    end
   end
 end

--- a/spec/factories/civil_entries.rb
+++ b/spec/factories/civil_entries.rb
@@ -4,5 +4,11 @@ FactoryGirl.define do
   factory :civil_entry do
     sequence(:serial) {|n| n}
     reason "This is a reason"
+    reviewed true
+  end
+  factory :unreviewed_civil_entry, :class => CivilEntry do
+    sequence(:serial) {|n| n}
+    reason "This is a reason"
+    reviewed false
   end
 end

--- a/spec/views/home/index.html.erb_spec.rb
+++ b/spec/views/home/index.html.erb_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+RSpec.describe "home/index.html.erb" do
+  context "When no reviewed entries exist" do
+    it "should display a message saying there are no civil entries at this time." do
+      assign(:civil_entries, [])
+
+      render
+
+      expect(rendered).to have_content("There are currently no entries at this time.")
+    end
+  end
+  context "When reviewed entries exist" do
+    it "should display those entries with their reasons" do
+      assign(:civil_entries, [create(:civil_entry, :reviewed => true, :address => "123 Place place")])
+
+      render
+
+      expect(rendered).to have_content("123 Place place")
+    end
+  end
+end

--- a/spec/views/home/index.html.erb_spec.rb
+++ b/spec/views/home/index.html.erb_spec.rb
@@ -11,8 +11,11 @@ RSpec.describe "home/index.html.erb" do
     end
   end
   context "When reviewed entries exist" do
-    it "should display those entries with their reasons" do
-      assign(:civil_entries, [create(:civil_entry, :reviewed => true, :address => "123 Place place")])
+    it "should display those entries" do
+      stubbed_model = stub_model(CivilEntry, :address => "123 Place place")
+      allow(stubbed_model).to receive(:created_at_formatted).and_return("123")
+
+      assign(:civil_entries, [stubbed_model])
 
       render
 

--- a/spec/views/home/index.html.erb_spec.rb
+++ b/spec/views/home/index.html.erb_spec.rb
@@ -12,9 +12,6 @@ RSpec.describe "home/index.html.erb" do
   end
   context "When reviewed entries exist" do
     it "should display those entries" do
-      stubbed_model = stub_model(CivilEntry, :address => "123 Place place")
-      allow(stubbed_model).to receive(:created_at_formatted).and_return("123")
-
       assign(:civil_entries, [stubbed_model])
 
       render
@@ -22,4 +19,10 @@ RSpec.describe "home/index.html.erb" do
       expect(rendered).to have_content("123 Place place")
     end
   end
+end
+
+def stubbed_model
+  stubbed_model = stub_model(CivilEntry, :address => "123 Place place")
+  allow(stubbed_model).to receive(:created_at_formatted).and_return("123")
+  stubbed_model
 end

--- a/spec/views/review/index.html.erb_spec.rb
+++ b/spec/views/review/index.html.erb_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe "review/index.html.erb" do
   end
   context "When unreviewed entries exist" do
     it "should display those entries with their reasons" do
-      assign(:unreviewed_civil_entries, [create(:civil_entry, :reviewed => false, :reason => "All the reasons!")])
+      assign(:unreviewed_civil_entries, [create(:unreviewed_civil_entry)])
 
       render
 
-      expect(rendered).to have_content("All the reasons!")
+      expect(rendered).to have_content("This is a reason")
     end
   end
 end

--- a/spec/views/review/index.html.erb_spec.rb
+++ b/spec/views/review/index.html.erb_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+RSpec.describe "review/index.html.erb" do
+  context "When no unreviewed entries exist" do
+    it "should display a message saying there are no entries to review" do
+      assign(:unreviewed_civil_entries, [])
+
+      render
+
+      expect(rendered).to have_content("There are currently no entries that need to be reviewed.")
+    end
+  end
+  context "When unreviewed entries exist" do
+    it "should display those entries with their reasons" do
+      assign(:unreviewed_civil_entries, [create(:civil_entry, :reviewed => false, :reason => "All the reasons!")])
+
+      render
+
+      expect(rendered).to have_content("All the reasons!")
+    end
+  end
+end


### PR DESCRIPTION
Fixes #40 and Fixes #44 This adds the necessary controllers and pages to view both reviewed and unreviewed items. On the home page you can see only reviewed items and on the review index page you can only see unreviewed items. I also forced the controllers to pick out only reviewed and unreviewed items depending on which controller it is. 