### PR TITLE
updated unreviewed entries query

### DIFF
--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -36,6 +36,6 @@ class ReviewController < AdminController
   end
 
   def unreviewed_entries
-    CivilEntry.where(:reviewed => false)
+    CivilEntry.where(:reviewed => false).where.not(:address => nil).where.not(:reason => nil)
   end
 end

--- a/spec/factories/civil_entries.rb
+++ b/spec/factories/civil_entries.rb
@@ -4,6 +4,7 @@ FactoryGirl.define do
   factory :civil_entry do
     sequence(:serial) {|n| n}
     reason "This is a reason"
+    address "Corvallis, OR"
     reviewed true
     trait :unreviewed_civil_entry do
       reviewed false


### PR DESCRIPTION
The issue was fixed by updating the filter that defines the unreviewed_entries output to properly reflect valid items that need review (with reason and address)

fixes #105 